### PR TITLE
Add new @github exception to allowlist

### DIFF
--- a/tools/gitleaks/config.toml
+++ b/tools/gitleaks/config.toml
@@ -174,7 +174,7 @@
 	[rules.allowlist]
 		regexes = [
 			'''(hello|acm-contact|quay-devel)@redhat\.com''',
-			'''(?i)(git|x-oauth-basic|GITHUB_TOKEN|GIT_AUTH_TOKEN)@github(\.ibm)?\.com''',
+			'''(?i)(git(hub-actions)?|x-oauth-basic|GITHUB_TOKEN|GIT_AUTH_TOKEN)@github(\.ibm)?\.com''',
 			'''[a-zA-Z0-9._%+-]+@users\.noreply\.github\.com''',
 			'''signer(2)?@enterprise\.com''',
 			'''sample_signer@signer.com''',


### PR DESCRIPTION
An email github-actions@github.com is being used for a github action
which is flagging a false positive. Added a new variation to the email
allowlist regex to ignore this.

Refs:
 - https://github.com/stolostron/backlog/issues/19702

Signed-off-by: Patrick Hickey <pahickey@redhat.com>