### PR TITLE
Update golang builder version and trigger rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
 ENV SEC_BIN /SEC/bin
 ENV SEC_ETC /SEC/etc
 RUN mkdir -p $SEC_BIN


### PR DESCRIPTION
Update the builder to use `golang:1.17` which will also trigger an
image rebuild to resolve the currently vulnerable packages.

Refs:
 - https://quay.io/repository/stolostron/sec/manifest/sha256:0e4c29fef86b295523142f070fb0ac302ff30a3b236574f40eda92bc1477e417?tab=vulnerabilities

Signed-off-by: Patrick Hickey <pahickey@redhat.com>