### PR TITLE
Update to use Python 3.9

### DIFF
--- a/tools/bandit/install
+++ b/tools/bandit/install
@@ -1,6 +1,6 @@
 
 # Install any required packages. The package manager in use is microdnf
-microdnf install python3
+microdnf install python39
 pip3 install bandit
 
 microdnf clean all

--- a/tools/kubiscan/install
+++ b/tools/kubiscan/install
@@ -1,6 +1,6 @@
 
 # Install any required packages. The package manager in use is microdnf
-microdnf install python3 git python3-pip
+microdnf install python39 git
 
 microdnf clean all
 
@@ -10,4 +10,3 @@ pip3 install PTable
 git clone https://github.com/gparvin/KubiScan.git
 
 # run kubiscan with: python3 /tmp/KubiScan/KubiScan.py
-

--- a/tools/njsscan/install
+++ b/tools/njsscan/install
@@ -4,7 +4,7 @@
 
 # Install any required packages. The package manager in use is microdnf
 # ex) microdnf install python3
-microdnf install python3 which
+microdnf install python39 which
 
 # Install application 
 pip3 install --upgrade njsscan


### PR DESCRIPTION
By explicitly defining `microdnf install python39` instead of
`microdnf install python3`, which defaults to Python 3.6.8, we install
`pip 20.2.4` instead of `pip 9.0.3` which is flagged as vulnerable
on Quay.

Refs:
 - https://quay.io/repository/stolostron/sec/manifest/sha256:2c96d9b1b0585dd9c749a176e5a0b9ab0adad7fcd067aadac674c6f4ef451a71?tab=vulnerabilities&fixable=true

Signed-off-by: Patrick Hickey <pahickey@redhat.com>