### PR TITLE
Add hostname exceptions

### DIFF
--- a/tools/gitleaks/config.toml
+++ b/tools/gitleaks/config.toml
@@ -247,7 +247,8 @@
 			'''Password\",type=\"string\"''',
 			'''PWD: \'pass-viewer''',
 			'''PASSWORD \|\| Cypress.env\(\'OPTIONS_HUB_PASSWORD''',
-			'''Password:( *)\"REDACTED\"'''
+			'''Password:( *)\"REDACTED\"''',
+			'''['|"](my-host|other-host)[0-9]*['|"]'''
 		]
 
 [[rules]]


### PR DESCRIPTION
Fixes https://github.com/stolostron/backlog/issues/24053

Allow for "my-host" and "other-host" (with optional appended numbers).