### PR TITLE
Ignore Sonar GHA false positive in gitleaks

### DIFF
--- a/tools/gitleaks/config.toml
+++ b/tools/gitleaks/config.toml
@@ -48,7 +48,8 @@
 	tags = ["key", "Github"]
 	[rules.allowlist]
 		regexes = [
-			'''\"image/png\": \"[0-9a-zA-Z\/+]{1,}(=){0,2}\\n\"'''
+			'''\"image/png\": \"[0-9a-zA-Z\/+]{1,}(=){0,2}\\n\"''',
+			'''sonarsource/sonarcloud-github-action@'''
 		]
 
 [[rules]]


### PR DESCRIPTION
Add an exclusion to the gitleaks GitHub key rule to avoid a false
positive on the SonarCloud GitHub Action with a SHA version.

Closes: stolostron/backlog#24803
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>