### PR TITLE
Add ignore for GitHub Actions' "uses: name@SHA"

### DIFF
--- a/tools/gitleaks/config.toml
+++ b/tools/gitleaks/config.toml
@@ -49,7 +49,7 @@
 	[rules.allowlist]
 		regexes = [
 			'''\"image/png\": \"[0-9a-zA-Z\/+]{1,}(=){0,2}\\n\"''',
-			'''sonarsource/sonarcloud-github-action@'''
+			'''uses: [a-zA-Z0-9_/-]*@[0-9a-f]{40}\b'''
 		]
 
 [[rules]]


### PR DESCRIPTION
GitHub Actions should use SHA-based versions for security, but they are flagged by gitleaks as potential secret keys.

Convert a regex for one GitHub Action to a generic regex to ignore all GitHub Action `uses: any-name@FULLSHA` config.

This regex should match GHA config like:

```
uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
uses: gr2m/twitter-together@51a5991dc8c534bb86253aef9359dac9d82e9474
uses: github/codeql-action/init@b398f525a5587552e573b247ac661067fafa920b
```

Closes: stolostron/backlog#25452
Closes: stolostron/backlog#25570
Closes: stolostron/backlog#25747
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>