### PR TITLE
Add ability to ignore inline with #notgitleak

### DIFF
--- a/tools/gitleaks/config.toml
+++ b/tools/gitleaks/config.toml
@@ -313,3 +313,7 @@
 	'''reposcan.md'''
 	]
 	paths = ['''node(-|_)modules''', '''vendor''', '''vbh''']
+
+[allowlist]
+    description = "Ignore lines with #notgitleak"
+    regexes = ['''#notgitleak''']


### PR DESCRIPTION
This should allow false positives flagged by gitleaks to be ignored by adding `#notgitleak` to the same line.

There isn't upstream support for inline ignores, they suggest this custom method:

zricethezav/gitleaks#579

It would be nicer if this could support ignoring either the line the ignore is on or the next line if it's on a line without an issue.

This is necessary for code that does contain names that sound like
secrets, and so shouldn't be ignored globally, but are not secrets.

For example:

```
//#nosec G101 -- This is the name of a key that will store a secret, but not a default secret
accessKeySecretKey = "aws_secret_access_key"
```

https://github.com/stolostron/submariner-addon/blob/main/pkg/cloud/aws/aws.go#L23


Signed-off-by: Daniel Farrell <dfarrell@redhat.com>